### PR TITLE
Use http protocol for https_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,28 @@
-#export-proxies
+# export-proxies
 
 A simple tool for exporting OS X proxy settings as environment variables.
 
-##Usage
+## Usage
+
 Build export-proxies using Xcode. Then add
 ```sh
 eval `./path/to/export-proxies`
 ```
 to your .profile, .bach_profile, .bashrc, or whatever file you're using to set up your environment.
 
-##Credits
+NOTE:
+
+If you want to use http protocol for https proxy, you should run
+```sh
+eval `./path/to/export-proxies --use-http-protocol-for-https-proxy`
+```
+instead.
+
+## Credits
+
 This was inspired by Mark Assad's [proxy-config](http://sydney.edu.au/engineering/it/~massad/project-proxy-config.html) that does not work with OS X 10.10.
+
+Authors:
+
+- [@janvogt](https://github.com/janvogt)
+- [@mckelvin](https://github.com/mckelvin)

--- a/export-proxies/ProxySettings.swift
+++ b/export-proxies/ProxySettings.swift
@@ -48,10 +48,16 @@ class ProxySettings {
         }
         var protocolName: String? {
             get {
+                var httpsProxyProtocol: String = "https"
+                if CommandLine.argc == 2 {
+                    if CommandLine.arguments[1] == "--use-http-protocol-for-https-proxy" {
+                        httpsProxyProtocol = "http"
+                    }
+                }
                 var proto: String?
                 switch self {
                 case .http: proto = "http"
-                case .https: proto = "https"
+                case .https: proto = httpsProxyProtocol
                 case .ftp: proto = "ftp"
                 case .socks: proto = "socks"
                 default: break


### PR DESCRIPTION
In my setup, I still use the `http` protocol for `https_proxy`. I think it's a common way how people use https_proxy. So I think it's better to change the protocol to `http`. A better way maybe providing a cli argument `--use-http-protocol-for-https-proxy`, please let me know if you think it's essential.

When I was using `OS 10.10` or maybe lower. It worked even if I use `https_proxy="https://127.0.0.1:61"` towards a http proxy server, but right now(`macOS 10.12`) I have to use `export https_proxy="http://127.0.0.1:61"`:

```
$ export https_proxy="https://127.0.0.1:61"
$ curl https://google.com
curl: (7) Unsupported proxy scheme for 'https://127.0.0.1:61'
$ export https_proxy="http://127.0.0.1:61"
$ curl https://google.com
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
...
```

NOTE: This PR is conflict with #1 . If both look good, please merge #1 first and I'll resolve the conflict  in this PR.